### PR TITLE
Remove code that replaces account key kid with external account binding

### DIFF
--- a/acme4j-client/src/main/java/org/shredzone/acme4j/AccountBuilder.java
+++ b/acme4j-client/src/main/java/org/shredzone/acme4j/AccountBuilder.java
@@ -182,9 +182,6 @@ public class AccountBuilder {
             URL location = conn.getLocation();
 
             Account account = new Account(session, location);
-            if (keyIdentifier != null) {
-                session.setKeyIdentifier(keyIdentifier);
-            }
 
             if (resp == HttpURLConnection.HTTP_CREATED) {
                 account.setJSON(conn.readJsonResponse());

--- a/acme4j-client/src/test/java/org/shredzone/acme4j/AccountBuilderTest.java
+++ b/acme4j-client/src/test/java/org/shredzone/acme4j/AccountBuilderTest.java
@@ -179,7 +179,6 @@ public class AccountBuilderTest {
         Account account = builder.create(session);
 
         assertThat(account.getLocation(), is(locationUrl));
-        assertThat(session.getKeyIdentifier(), is(keyIdentifier));
 
         provider.close();
     }


### PR DESCRIPTION
kid after the external account binding process is done.

Relevant discussion on IETF ACME mailing list: https://mailarchive.ietf.org/arch/search/?email_list=acme&gbt=1&index=_j_xfYp9rlLeAtOWtSuQ-UtX3k0