### PR TITLE
Differentiate between writing end-entity, intermediate, and all certs.

### DIFF
--- a/acme4j-client/src/main/java/org/shredzone/acme4j/Certificate.java
+++ b/acme4j-client/src/main/java/org/shredzone/acme4j/Certificate.java
@@ -115,16 +115,50 @@ public class Certificate extends AcmeResource {
     }
 
     /**
-     * Writes the certificate to the given writer. It is written in PEM format, with the
-     * end-entity cert coming first, followed by the intermediate ceritificates.
+     * Writes the certificate and the intermediate certificates to the given writer.
+     * They are written in PEM format, with the end-entity cert coming first, followed
+     * by the intermediate certificates.
+     *
+     * @param out
+     *            {@link Writer} to write to. The writer is not closed after use.
+     */
+    public void writeCertificateAndChain(@WillNotClose Writer out) throws IOException {
+        try {
+            for (X509Certificate cert : getCertificateChain()) {
+                AcmeUtils.writeToPem(cert.getEncoded(), AcmeUtils.PemLabel.CERTIFICATE, out);
+            }
+        } catch (CertificateEncodingException ex) {
+            throw new IOException("Encoding error", ex);
+        }
+    }
+
+    /**
+     * Writes the certificate to the given writer. It is written in PEM format.
      *
      * @param out
      *            {@link Writer} to write to. The writer is not closed after use.
      */
     public void writeCertificate(@WillNotClose Writer out) throws IOException {
         try {
+            AcmeUtils.writeToPem(getCertificate().getEncoded(), AcmeUtils.PemLabel.CERTIFICATE, out);
+        } catch (CertificateEncodingException ex) {
+            throw new IOException("Encoding error", ex);
+        }
+    }
+
+    /**
+     * Writes the intermediate certificates to the given writer. They are written in
+     * PEM format. The list is sorted, following certificates certify preceding ones.
+     *
+     * @param out
+     *            {@link Writer} to write to. The writer is not closed after use.
+     */
+    public void writeChain(@WillNotClose Writer out) throws IOException {
+        try {
             for (X509Certificate cert : getCertificateChain()) {
-                AcmeUtils.writeToPem(cert.getEncoded(), AcmeUtils.PemLabel.CERTIFICATE, out);
+                if (cert != getCertificate()) {
+                    AcmeUtils.writeToPem(cert.getEncoded(), AcmeUtils.PemLabel.CERTIFICATE, out);
+                }
             }
         } catch (CertificateEncodingException ex) {
             throw new IOException("Encoding error", ex);

--- a/acme4j-client/src/main/java/org/shredzone/acme4j/Certificate.java
+++ b/acme4j-client/src/main/java/org/shredzone/acme4j/Certificate.java
@@ -118,6 +118,21 @@ public class Certificate extends AcmeResource {
      * Writes the certificate and the intermediate certificates to the given writer.
      * They are written in PEM format, with the end-entity cert coming first, followed
      * by the intermediate certificates.
+     * This method just calls writeCertificateAndChain.
+     * 
+     * @see #writeCertificateAndChain
+     *
+     * @param out
+     *            {@link Writer} to write to. The writer is not closed after use.
+     */
+    public void writeCertificate(@WillNotClose Writer out) throws IOException {
+        writeCertificateAndChain(out);
+    }
+
+    /**
+     * Writes the certificate and the intermediate certificates to the given writer.
+     * They are written in PEM format, with the end-entity cert coming first, followed
+     * by the intermediate certificates.
      *
      * @param out
      *            {@link Writer} to write to. The writer is not closed after use.
@@ -138,7 +153,7 @@ public class Certificate extends AcmeResource {
      * @param out
      *            {@link Writer} to write to. The writer is not closed after use.
      */
-    public void writeCertificate(@WillNotClose Writer out) throws IOException {
+    public void writeCertificateOnly(@WillNotClose Writer out) throws IOException {
         try {
             AcmeUtils.writeToPem(getCertificate().getEncoded(), AcmeUtils.PemLabel.CERTIFICATE, out);
         } catch (CertificateEncodingException ex) {


### PR DESCRIPTION
I thought it would be useful to be able, to just write out the end-entity certificate.
Now after having finished coding, I am getting aware, that I don't need it, because I can configure my mail server with end cert and intermediate in one file :-)
Code is finished, so I send it anyway.
This also fixes:
* Typo in comment: ceritificates
* Method name: better name would be `writeCertificateAndChain` instead of `writeCertificate`