### PR TITLE
PebbleAcmeProvider: allow setting custom port w/o custom host

### DIFF
--- a/acme4j-client/src/main/java/org/shredzone/acme4j/provider/pebble/PebbleAcmeProvider.java
+++ b/acme4j-client/src/main/java/org/shredzone/acme4j/provider/pebble/PebbleAcmeProvider.java
@@ -37,6 +37,7 @@ import org.shredzone.acme4j.provider.AcmeProvider;
 public class PebbleAcmeProvider extends AbstractAcmeProvider {
 
     private static final Pattern HOST_PATTERN = Pattern.compile("^/([^:/]+)(?:\\:(\\d+))?/?$");
+    private static final int PEBBLE_DEFAULT_PORT = 14000;
 
     @Override
     public boolean accepts(URI serverUri) {
@@ -47,8 +48,9 @@ public class PebbleAcmeProvider extends AbstractAcmeProvider {
     public URL resolve(URI serverUri) {
         try {
             var path = serverUri.getPath();
+            int port = serverUri.getPort() != -1 ? serverUri.getPort() : PEBBLE_DEFAULT_PORT;
 
-            var baseUrl = new URL("https://localhost:14000/dir");
+            var baseUrl = new URL("https://localhost:" + port + "/dir");
 
             if (path != null && !path.isEmpty() && !"/".equals(path)) {
                 baseUrl = parsePath(path);
@@ -71,7 +73,7 @@ public class PebbleAcmeProvider extends AbstractAcmeProvider {
         var m = HOST_PATTERN.matcher(path);
         if (m.matches()) {
             var host = m.group(1);
-            var port = 14000;
+            var port = PEBBLE_DEFAULT_PORT;
             if (m.group(2) != null) {
                 port = Integer.parseInt(m.group(2));
             }

--- a/acme4j-client/src/test/java/org/shredzone/acme4j/provider/pebble/PebbleAcmeProviderTest.java
+++ b/acme4j-client/src/test/java/org/shredzone/acme4j/provider/pebble/PebbleAcmeProviderTest.java
@@ -38,6 +38,8 @@ public class PebbleAcmeProviderTest {
         try (var softly = new AutoCloseableSoftAssertions()) {
             softly.assertThat(provider.accepts(new URI("acme://pebble"))).isTrue();
             softly.assertThat(provider.accepts(new URI("acme://pebble/"))).isTrue();
+            softly.assertThat(provider.accepts(new URI("acme://pebble:12345"))).isTrue();
+            softly.assertThat(provider.accepts(new URI("acme://pebble:12345/"))).isTrue();
             softly.assertThat(provider.accepts(new URI("acme://pebble/some-host.example.com"))).isTrue();
             softly.assertThat(provider.accepts(new URI("acme://pebble/some-host.example.com:12345"))).isTrue();
             softly.assertThat(provider.accepts(new URI("acme://example.com"))).isFalse();
@@ -57,6 +59,10 @@ public class PebbleAcmeProviderTest {
                 .isEqualTo(url("https://localhost:14000/dir"));
         assertThat(provider.resolve(new URI("acme://pebble/")))
                 .isEqualTo(url("https://localhost:14000/dir"));
+        assertThat(provider.resolve(new URI("acme://pebble:12345")))
+            .isEqualTo(url("https://localhost:12345/dir"));
+        assertThat(provider.resolve(new URI("acme://pebble:12345/")))
+            .isEqualTo(url("https://localhost:12345/dir"));
         assertThat(provider.resolve(new URI("acme://pebble/pebble.example.com")))
                 .isEqualTo(url("https://pebble.example.com:14000/dir"));
         assertThat(provider.resolve(new URI("acme://pebble/pebble.example.com:12345")))

--- a/src/doc/docs/ca/pebble.md
+++ b/src/doc/docs/ca/pebble.md
@@ -7,6 +7,7 @@ This ACME provider can be used to connect to a local Pebble server instance, mai
 ## Connection URIs
 
 * `acme://pebble` - Connect to a Pebble server at `localhost` and standard port 14000.
+* `acme://pebble:12345` - Connect to a Pebble server at `localhost` and port 12345.
 * `acme://pebble/pebble.example.com` - Connect to a Pebble server at `pebble.example.com` and standard port 14000.
 * `acme://pebble/pebble.example.com:12345` - Connect to a Pebble server at `pebble.example.com` and port 12345.
 


### PR DESCRIPTION
Simplifies usage with testcontainers where the Pebble port in the Docker container usually gets mapped to a random host port.