### PR TITLE
Accepting hmac key of all sizes

### DIFF
--- a/acme4j-client/src/main/java/org/shredzone/acme4j/toolbox/JoseUtils.java
+++ b/acme4j-client/src/main/java/org/shredzone/acme4j/toolbox/JoseUtils.java
@@ -245,19 +245,16 @@ public final class JoseUtils {
         }
 
         var size = macKey.getEncoded().length * 8;
-        switch (size) {
-            case 256:
-                return AlgorithmIdentifiers.HMAC_SHA256;
-
-            case 384:
-                return AlgorithmIdentifiers.HMAC_SHA384;
-
-            case 512:
+        if (size >= 256) {
+            if (size >= 512) {
                 return AlgorithmIdentifiers.HMAC_SHA512;
-
-            default:
-                throw new IllegalArgumentException("Bad key size: " + size);
+            } else if (size >= 384) {
+                return AlgorithmIdentifiers.HMAC_SHA384;
+            } else {
+                return AlgorithmIdentifiers.HMAC_SHA256;
+            }
+        } else {
+            throw new IllegalArgumentException("Bad key size: " + size);
         }
     }
-
 }

--- a/acme4j-client/src/main/java/org/shredzone/acme4j/toolbox/JoseUtils.java
+++ b/acme4j-client/src/main/java/org/shredzone/acme4j/toolbox/JoseUtils.java
@@ -245,16 +245,15 @@ public final class JoseUtils {
         }
 
         var size = macKey.getEncoded().length * 8;
-        if (size >= 256) {
-            if (size >= 512) {
-                return AlgorithmIdentifiers.HMAC_SHA512;
-            } else if (size >= 384) {
-                return AlgorithmIdentifiers.HMAC_SHA384;
-            } else {
-                return AlgorithmIdentifiers.HMAC_SHA256;
-            }
-        } else {
+        if(size < 256) {
             throw new IllegalArgumentException("Bad key size: " + size);
+        }
+        if (size >= 512) {
+            return AlgorithmIdentifiers.HMAC_SHA512;
+        } else if (size >= 384) {
+            return AlgorithmIdentifiers.HMAC_SHA384;
+        } else {
+            return AlgorithmIdentifiers.HMAC_SHA256;
         }
     }
 }


### PR DESCRIPTION
Currently there is an issue with the method macKeyAlgorithm(SecretKey macKey).

If the HMAC algorithm is used and if the size of the mac key is greater than the size of hash output it throws the IllegalArgumentException "Bad key size:".

But in ACME protocol, arbitrary key lengths are allowed and they just need to be longer than the minimum. A key of the same size as the hash output (for instance, 256 bits for "HS256") or larger MUST be used with this algorithm.
