### PR TITLE
Make Common Name optional in CSRs

### DIFF
--- a/acme4j-client/src/main/java/org/shredzone/acme4j/util/CSRBuilder.java
+++ b/acme4j-client/src/main/java/org/shredzone/acme4j/util/CSRBuilder.java
@@ -213,7 +213,6 @@ public class CSRBuilder {
     public void addValue(ASN1ObjectIdentifier oid, String value) {
         if (requireNonNull(oid, "OID must not be null").equals(BCStyle.CN)) {
             addDomain(value);
-            return;
         }
         namebuilder.addRDN(oid, requireNonNull(value, "attribute value must not be null"));
     }
@@ -224,7 +223,7 @@ public class CSRBuilder {
      * Note that it is at the discretion of the ACME server to accept this parameter.
      */
     public void setCommonName(String cn) {
-        namebuilder.addRDN(BCStyle.CN, toAce(requireNonNull(cn)));
+        addValue(BCStyle.CN, cn);
     }
 
     /**

--- a/acme4j-client/src/main/java/org/shredzone/acme4j/util/CSRBuilder.java
+++ b/acme4j-client/src/main/java/org/shredzone/acme4j/util/CSRBuilder.java
@@ -78,11 +78,7 @@ public class CSRBuilder {
      *            Domain name to add
      */
     public void addDomain(String domain) {
-        var ace = toAce(requireNonNull(domain));
-        if (namelist.isEmpty()) {
-            namebuilder.addRDN(BCStyle.CN, ace);
-        }
-        namelist.add(ace);
+        namelist.add(toAce(requireNonNull(domain)));
     }
 
     /**
@@ -220,6 +216,15 @@ public class CSRBuilder {
             return;
         }
         namebuilder.addRDN(oid, requireNonNull(value, "attribute value must not be null"));
+    }
+
+    /**
+     * Sets the common name
+     * <p>
+     * Note that it is at the discretion of the ACME server to accept this parameter.
+     */
+    public void setCommonName(String cn) {
+        namebuilder.addRDN(BCStyle.CN, toAce(requireNonNull(cn)));
     }
 
     /**

--- a/acme4j-client/src/main/java/org/shredzone/acme4j/util/CertificateUtils.java
+++ b/acme4j-client/src/main/java/org/shredzone/acme4j/util/CertificateUtils.java
@@ -270,7 +270,8 @@ public final class CertificateUtils {
                 var extensions = attr[0].getAttrValues().toArray();
                 if (extensions.length > 0 && extensions[0] instanceof Extensions) {
                     var san = GeneralNames.fromExtensions((Extensions) extensions[0], Extension.subjectAlternativeName);
-                    certBuilder.addExtension(Extension.subjectAlternativeName, false, san);
+                    var critical = csr.getSubject().getRDNs().length == 0;
+                    certBuilder.addExtension(Extension.subjectAlternativeName, critical, san);
                 }
             }
 

--- a/acme4j-client/src/test/java/org/shredzone/acme4j/util/CSRBuilderTest.java
+++ b/acme4j-client/src/test/java/org/shredzone/acme4j/util/CSRBuilderTest.java
@@ -218,6 +218,7 @@ public class CSRBuilderTest {
         builder.addIdentifiers(Identifier.dns("ide2.nt"), Identifier.ip("192.168.5.6"));
         builder.addIdentifiers(Arrays.asList(Identifier.dns("ide3.nt"), Identifier.ip("192.168.5.7")));
 
+        builder.setCommonName("abc.de");
         builder.setCountry("XX");
         builder.setLocality("Testville");
         builder.setOrganization("Testing Co");

--- a/acme4j-client/src/test/java/org/shredzone/acme4j/util/CSRBuilderTest.java
+++ b/acme4j-client/src/test/java/org/shredzone/acme4j/util/CSRBuilderTest.java
@@ -189,7 +189,7 @@ public class CSRBuilderTest {
         builder.addValue("CN", "firstcn.example.com");
         assertThat(builder.toString()).isEqualTo("C=DE,E=contact@example.com,CN=firstcn.example.com,DNS=firstcn.example.com");
         builder.addValue("CN", "scnd.example.com");
-        assertThat(builder.toString()).isEqualTo("C=DE,E=contact@example.com,CN=firstcn.example.com,DNS=firstcn.example.com,DNS=scnd.example.com");
+        assertThat(builder.toString()).isEqualTo("C=DE,E=contact@example.com,CN=firstcn.example.com,CN=scnd.example.com,DNS=firstcn.example.com,DNS=scnd.example.com");
         
         builder = new CSRBuilder();
         builder.addValue(BCStyle.C, "DE");
@@ -199,7 +199,7 @@ public class CSRBuilderTest {
         builder.addValue(BCStyle.CN, "firstcn.example.com");
         assertThat(builder.toString()).isEqualTo("C=DE,E=contact@example.com,CN=firstcn.example.com,DNS=firstcn.example.com");
         builder.addValue(BCStyle.CN, "scnd.example.com");
-        assertThat(builder.toString()).isEqualTo("C=DE,E=contact@example.com,CN=firstcn.example.com,DNS=firstcn.example.com,DNS=scnd.example.com");
+        assertThat(builder.toString()).isEqualTo("C=DE,E=contact@example.com,CN=firstcn.example.com,CN=scnd.example.com,DNS=firstcn.example.com,DNS=scnd.example.com");
     }
 
     private CSRBuilder createBuilderWithValues() throws UnknownHostException {

--- a/acme4j-client/src/test/java/org/shredzone/acme4j/util/CertificateUtilsTest.java
+++ b/acme4j-client/src/test/java/org/shredzone/acme4j/util/CertificateUtilsTest.java
@@ -228,7 +228,7 @@ public class CertificateUtilsTest {
                 notAfter, rootCert, rootKeypair.getPrivate());
 
         assertThat(cert.getIssuerX500Principal().getName()).isEqualTo(rootSubject);
-        assertThat(cert.getSubjectX500Principal().getName()).isEqualTo("CN=example.org");
+        assertThat(cert.getSubjectX500Principal().getName()).isEqualTo("");
         assertThat(getSANs(cert)).contains("example.org", "www.example.org");
         assertThat(getIpSANs(cert)).contains(InetAddress.getByName("192.168.0.1"));
         assertThat(cert.getNotBefore().toInstant()).isEqualTo(notBefore);


### PR DESCRIPTION
This change makes the common name optional in CSRs.

The CN field is length-limited to 64 characters, so trying to request a certificate with the first (or all) domains longer than 64 characters creates an invalid CSR.  This isn't the only way to solve this problem, but it's arguably the future-proof option.

The CN, at least for Let's Encrypt, isn't required to be in the CSR at all.  The first eligible SAN is automatically promoted by LE.

As well, the Common Name is "not recommended" by the current baseline requirements.  It may be removed from all certificates in the future.

One weird side affect, as documented by the final test change, is that you can set two CNs now, which doesn't seem ideal, but maybe isn't worth solving either, as I don't know why anyone would do that.