### PR TITLE
Add support for acme profiles

### DIFF
--- a/acme4j-client/src/main/java/org/shredzone/acme4j/Metadata.java
+++ b/acme4j-client/src/main/java/org/shredzone/acme4j/Metadata.java
@@ -132,6 +132,31 @@ public class Metadata {
     }
 
     /**
+     * Returns whether the CA supports the profile feature.
+     *
+     * @since 3.5
+     * @throws AcmeNotSupportedException if the server does not support the profile feature.
+     */
+    public boolean isProfileAllowed() {
+        return meta.getFeature("profile").optional().isPresent();
+    }
+
+    /**
+     * Returns whether the CA supports the requested profile.
+     *
+     * @since 3.5
+     * @throws AcmeNotSupportedException if the server does not support the requested profile.
+     */
+    public boolean isProfileAllowed(String profile) {
+        return meta.getFeature("profile").optional()
+                .map(Value::asObject)
+                .orElseGet(JSON::empty)
+                .get(profile)
+                .optional()
+                .isPresent();
+    }
+
+    /**
      * Returns whether the CA supports subdomain auth according to RFC9444.
      *
      * @since 3.3.0

--- a/acme4j-client/src/main/java/org/shredzone/acme4j/Order.java
+++ b/acme4j-client/src/main/java/org/shredzone/acme4j/Order.java
@@ -437,6 +437,16 @@ public class Order extends AcmeJsonResource implements PollableResource {
         }
     }
 
+    /**
+     * Returns the selected profile.
+     *
+     * @since 2.3
+     * @throws AcmeNotSupportedException if profile is not supported
+     */
+    public String getProfile() {
+        return getJSON().getFeature("profile").toString();
+    }
+
     @Override
     protected void invalidate() {
         super.invalidate();

--- a/acme4j-client/src/main/java/org/shredzone/acme4j/Order.java
+++ b/acme4j-client/src/main/java/org/shredzone/acme4j/Order.java
@@ -440,7 +440,7 @@ public class Order extends AcmeJsonResource implements PollableResource {
     /**
      * Returns the selected profile.
      *
-     * @since 2.3
+     * @since 3.5
      * @throws AcmeNotSupportedException if profile is not supported
      */
     public String getProfile() {

--- a/acme4j-client/src/test/java/org/shredzone/acme4j/OrderBuilderTest.java
+++ b/acme4j-client/src/test/java/org/shredzone/acme4j/OrderBuilderTest.java
@@ -116,6 +116,8 @@ public class OrderBuilderTest {
                     .isThrownBy(order::getAutoRenewalLifetimeAdjust);
             softly.assertThatExceptionOfType(AcmeNotSupportedException.class)
                     .isThrownBy(order::isAutoRenewalGetEnabled);
+            softly.assertThatExceptionOfType(AcmeNotSupportedException.class)
+                    .isThrownBy(order::getProfile);
             softly.assertThat(order.getLocation()).isEqualTo(locationUrl);
             softly.assertThat(order.getAuthorizations()).isNotNull();
             softly.assertThat(order.getAuthorizations()).hasSize(2);
@@ -369,11 +371,16 @@ public class OrderBuilderTest {
         provider.putTestResource(Resource.NEW_ORDER, resourceUrl);
 
         var account = new Account(login);
-        account.newOrder()
+        var order = account.newOrder()
                 .domain("example.org")
                 .profile("classic")
                 .create();
 
+        try (var softly = new AutoCloseableSoftAssertions()) {
+            softly.assertThat(order.getProfile()).isEqualTo("classic");
+        }
+
+        provider.close();
         provider.close();
     }
 

--- a/acme4j-client/src/test/java/org/shredzone/acme4j/OrderTest.java
+++ b/acme4j-client/src/test/java/org/shredzone/acme4j/OrderTest.java
@@ -90,6 +90,8 @@ public class OrderTest {
                     .isThrownBy(order::getAutoRenewalLifetimeAdjust);
             softly.assertThatExceptionOfType(AcmeNotSupportedException.class)
                     .isThrownBy(order::isAutoRenewalGetEnabled);
+            softly.assertThatExceptionOfType(AcmeNotSupportedException.class)
+                    .isThrownBy(order::getProfile);
 
             softly.assertThat(order.getError()).isNotEmpty();
             softly.assertThat(order.getError().orElseThrow().getType())

--- a/acme4j-client/src/test/java/org/shredzone/acme4j/SessionTest.java
+++ b/acme4j-client/src/test/java/org/shredzone/acme4j/SessionTest.java
@@ -183,6 +183,9 @@ public class SessionTest {
             softly.assertThat(meta.getAutoRenewalMaxDuration()).isEqualTo(Duration.ofDays(365));
             softly.assertThat(meta.getAutoRenewalMinLifetime()).isEqualTo(Duration.ofHours(24));
             softly.assertThat(meta.isAutoRenewalGetAllowed()).isTrue();
+            softly.assertThat(meta.isProfileAllowed()).isTrue();
+            softly.assertThat(meta.isProfileAllowed("classic")).isTrue();
+            softly.assertThat(meta.isProfileAllowed("invalid")).isFalse();
             softly.assertThat(meta.isExternalAccountRequired()).isTrue();
             softly.assertThat(meta.isSubdomainAuthAllowed()).isTrue();
             softly.assertThat(meta.getJSON()).isNotNull();
@@ -235,6 +238,8 @@ public class SessionTest {
                     .isThrownBy(meta::getAutoRenewalMinLifetime);
             softly.assertThatExceptionOfType(AcmeNotSupportedException.class)
                     .isThrownBy(meta::isAutoRenewalGetAllowed);
+            softly.assertThat(meta.isProfileAllowed()).isFalse();
+            softly.assertThat(meta.isProfileAllowed("classic")).isFalse();
         }
     }
 

--- a/acme4j-client/src/test/resources/json/directory.json
+++ b/acme4j-client/src/test/resources/json/directory.json
@@ -23,6 +23,10 @@
       "foo",
       "bar",
       "barfoo"
-    ]
+    ],
+    "profiles": {
+      "classic": "The profile you're accustomed to",
+      "custom": "Some other profile"
+    }
   }
 }

--- a/acme4j-client/src/test/resources/json/requestProfileOrderRequest.json
+++ b/acme4j-client/src/test/resources/json/requestProfileOrderRequest.json
@@ -1,0 +1,9 @@
+{
+  "identifiers": [
+    {
+      "type": "dns",
+      "value": "example.org"
+    }
+  ],
+  "profile": "classic"
+}

--- a/acme4j-client/src/test/resources/json/requestProfileOrderResponse.json
+++ b/acme4j-client/src/test/resources/json/requestProfileOrderResponse.json
@@ -1,0 +1,16 @@
+{
+  "status": "pending",
+  "expires": "2016-01-10T00:00:00Z",
+  "identifiers": [
+    {
+      "type": "dns",
+      "value": "example.org"
+    }
+  ],
+  "authorizations": [
+    "https://example.com/acme/authz/1234",
+    "https://example.com/acme/authz/2345"
+  ],
+  "finalize": "https://example.com/acme/acct/1/order/1/finalize",
+  "profile": "classic"
+}


### PR DESCRIPTION
With the recent [announcement](https://letsencrypt.org/2025/01/09/acme-profiles/) of Let'sEncrypt staging support for acme profiles, it would be nice for clients to have some helpers to test out this feature similar to what's in place for other draft RFCs. I've added validation and tests for the Metadata, Order, and OrderBuilder components.