### PR TITLE
Add Session interface to allow override

### DIFF
--- a/acme4j-client/src/main/java/org/shredzone/acme4j/AccountBuilder.java
+++ b/acme4j-client/src/main/java/org/shredzone/acme4j/AccountBuilder.java
@@ -241,27 +241,27 @@ public class AccountBuilder {
      * Use this method to finally create your account with the given parameters. Do not
      * use the {@link AccountBuilder} after invoking this method.
      *
-     * @param session
+     * @param ISession
      *         {@link Session} to be used for registration
      * @return {@link Account} referring to the new account
-     * @see #createLogin(Session)
+     * @see #createLogin(ISession)
      */
-    public Account create(Session session) throws AcmeException {
-        return createLogin(session).getAccount();
+    public Account create(ISession ISession) throws AcmeException {
+        return createLogin(ISession).getAccount();
     }
 
     /**
      * Creates a new account.
      * <p>
-     * This method is identical to {@link #create(Session)}, but returns a {@link Login}
+     * This method is identical to {@link #create(ISession)}, but returns a {@link Login}
      * that is ready to be used.
      *
-     * @param session
+     * @param ISession
      *         {@link Session} to be used for registration
      * @return {@link Login} referring to the new account
      */
-    public Login createLogin(Session session) throws AcmeException {
-        requireNonNull(session, "session");
+    public Login createLogin(ISession ISession) throws AcmeException {
+        requireNonNull(ISession, "session");
 
         if (keyPair == null) {
             throw new IllegalStateException("Use AccountBuilder.useKeyPair() to set the account's key pair.");
@@ -269,8 +269,8 @@ public class AccountBuilder {
 
         LOG.debug("create");
 
-        try (var conn = session.connect()) {
-            var resourceUrl = session.resourceUrl(Resource.NEW_ACCOUNT);
+        try (var conn = ISession.connect()) {
+            var resourceUrl = ISession.resourceUrl(Resource.NEW_ACCOUNT);
 
             var claims = new JSONBuilder();
             if (!contacts.isEmpty()) {
@@ -281,7 +281,7 @@ public class AccountBuilder {
             }
             if (keyIdentifier != null && macKey != null) {
                 var algorithm = Optional.ofNullable(macAlgorithm)
-                        .or(session.provider()::getProposedEabMacAlgorithm)
+                        .or(ISession.provider()::getProposedEabMacAlgorithm)
 // FIXME: Cannot use a Supplier here due to a Spotbugs false positive "null pointer dereference"
                         .orElse(macKeyAlgorithm(macKey));
                 claims.put("externalAccountBinding", JoseUtils.createExternalAccountBinding(
@@ -291,9 +291,9 @@ public class AccountBuilder {
                 claims.put("onlyReturnExisting", onlyExisting);
             }
 
-            conn.sendSignedRequest(resourceUrl, claims, session, keyPair);
+            conn.sendSignedRequest(resourceUrl, claims, ISession, keyPair);
 
-            var login = new Login(conn.getLocation(), keyPair, session);
+            var login = new Login(conn.getLocation(), keyPair, ISession);
             login.getAccount().setJSON(conn.readJsonResponse());
             return login;
         }

--- a/acme4j-client/src/main/java/org/shredzone/acme4j/AcmeResource.java
+++ b/acme4j-client/src/main/java/org/shredzone/acme4j/AcmeResource.java
@@ -61,7 +61,7 @@ public abstract class AcmeResource implements Serializable {
     /**
      * Gets the {@link Session} this resource is bound with.
      */
-    protected Session getSession() {
+    protected ISession getSession() {
         return getLogin().getSession();
     }
 

--- a/acme4j-client/src/main/java/org/shredzone/acme4j/Certificate.java
+++ b/acme4j-client/src/main/java/org/shredzone/acme4j/Certificate.java
@@ -255,7 +255,7 @@ public class Certificate extends AcmeResource {
      *            used when generating OCSP responses and CRLs. {@code null} to give no
      *            reason.
      * @see #revoke(Login, X509Certificate, RevocationReason)
-     * @see #revoke(Session, KeyPair, X509Certificate, RevocationReason)
+     * @see #revoke(ISession, KeyPair, X509Certificate, RevocationReason)
      */
     public void revoke(@Nullable RevocationReason reason) throws AcmeException {
         revoke(getLogin(), getCertificate(), reason);
@@ -275,7 +275,7 @@ public class Certificate extends AcmeResource {
      * @param reason
      *         {@link RevocationReason} stating the reason of the revocation that is used
      *         when generating OCSP responses and CRLs. {@code null} to give no reason.
-     * @see #revoke(Session, KeyPair, X509Certificate, RevocationReason)
+     * @see #revoke(ISession, KeyPair, X509Certificate, RevocationReason)
      * @since 2.6
      */
     public static void revoke(Login login, X509Certificate cert, @Nullable RevocationReason reason)
@@ -306,7 +306,7 @@ public class Certificate extends AcmeResource {
      * login into your account), but you still have the key pair of the affected domain
      * and the issued certificate.
      *
-     * @param session
+     * @param ISession
      *         {@link Session} connected to the ACME server
      * @param domainKeyPair
      *         Key pair the CSR was signed with
@@ -317,20 +317,20 @@ public class Certificate extends AcmeResource {
      *         when generating OCSP responses and CRLs. {@code null} to give no reason.
      * @see #revoke(Login, X509Certificate, RevocationReason)
      */
-    public static void revoke(Session session, KeyPair domainKeyPair, X509Certificate cert,
-            @Nullable RevocationReason reason) throws AcmeException {
+    public static void revoke(ISession ISession, KeyPair domainKeyPair, X509Certificate cert,
+                              @Nullable RevocationReason reason) throws AcmeException {
         LOG.debug("revoke using the domain key pair");
 
-        var resUrl = session.resourceUrl(Resource.REVOKE_CERT);
+        var resUrl = ISession.resourceUrl(Resource.REVOKE_CERT);
 
-        try (var conn = session.connect()) {
+        try (var conn = ISession.connect()) {
             var claims = new JSONBuilder();
             claims.putBase64("certificate", cert.getEncoded());
             if (reason != null) {
                 claims.put("reason", reason.getReasonCode());
             }
 
-            conn.sendSignedRequest(resUrl, claims, session, domainKeyPair);
+            conn.sendSignedRequest(resUrl, claims, ISession, domainKeyPair);
         } catch (CertificateEncodingException ex) {
             throw new AcmeProtocolException("Invalid certificate", ex);
         }

--- a/acme4j-client/src/main/java/org/shredzone/acme4j/ISession.java
+++ b/acme4j-client/src/main/java/org/shredzone/acme4j/ISession.java
@@ -1,0 +1,61 @@
+package org.shredzone.acme4j;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.shredzone.acme4j.connector.Connection;
+import org.shredzone.acme4j.connector.NetworkSettings;
+import org.shredzone.acme4j.connector.Resource;
+import org.shredzone.acme4j.exception.AcmeException;
+import org.shredzone.acme4j.provider.AcmeProvider;
+
+import java.net.URI;
+import java.net.URL;
+import java.security.KeyPair;
+import java.time.ZonedDateTime;
+import java.util.Locale;
+import java.util.Optional;
+
+public interface ISession {
+    Login login(URL accountLocation, KeyPair accountKeyPair);
+
+    URI getServerUri();
+
+    @Nullable
+    String getNonce();
+
+    void setNonce(@Nullable String nonce);
+
+    @Nullable
+    Locale getLocale();
+
+    void setLocale(@Nullable Locale locale);
+
+    String getLanguageHeader();
+
+    @SuppressFBWarnings("EI_EXPOSE_REP")    // behavior is intended
+    NetworkSettings networkSettings();
+
+    AcmeProvider provider();
+
+    Connection connect();
+
+    URL resourceUrl(Resource resource) throws AcmeException;
+
+    Optional<URL> resourceUrlOptional(Resource resource) throws AcmeException;
+
+    Metadata getMetadata() throws AcmeException;
+
+    @Nullable
+    ZonedDateTime getDirectoryLastModified();
+
+    void setDirectoryLastModified(@Nullable ZonedDateTime directoryLastModified);
+
+    @Nullable
+    ZonedDateTime getDirectoryExpires();
+
+    void setDirectoryExpires(@Nullable ZonedDateTime directoryExpires);
+
+    boolean hasDirectory();
+
+    void purgeDirectoryCache();
+}

--- a/acme4j-client/src/main/java/org/shredzone/acme4j/Login.java
+++ b/acme4j-client/src/main/java/org/shredzone/acme4j/Login.java
@@ -51,7 +51,7 @@ import org.shredzone.acme4j.toolbox.JSON;
  */
 public class Login {
 
-    private final Session session;
+    private final ISession ISession;
     private final URL accountLocation;
     private final Account account;
     private KeyPair keyPair;
@@ -63,13 +63,13 @@ public class Login {
      *            Account location {@link URL}
      * @param keyPair
      *            {@link KeyPair} of the account
-     * @param session
+     * @param ISession
      *            {@link Session} to be used
      */
-    public Login(URL accountLocation, KeyPair keyPair, Session session) {
+    public Login(URL accountLocation, KeyPair keyPair, ISession ISession) {
         this.accountLocation = Objects.requireNonNull(accountLocation, "accountLocation");
         this.keyPair = Objects.requireNonNull(keyPair, "keyPair");
-        this.session = Objects.requireNonNull(session, "session");
+        this.ISession = Objects.requireNonNull(ISession, "session");
         this.account = new Account(this);
     }
 
@@ -77,8 +77,8 @@ public class Login {
      * Gets the {@link Session} that is used.
      */
     @SuppressFBWarnings("EI_EXPOSE_REP")    // behavior is intended
-    public Session getSession() {
-        return session;
+    public ISession getSession() {
+        return ISession;
     }
 
     /**
@@ -186,7 +186,7 @@ public class Login {
      * @see #bindChallenge(URL, Class)
      */
     public Challenge bindChallenge(URL location) {
-        try (var connect = session.connect()) {
+        try (var connect = ISession.connect()) {
             connect.sendSignedPostAsGetRequest(location, this);
             return createChallenge(connect.readJsonResponse());
         } catch (AcmeException ex) {
@@ -225,7 +225,7 @@ public class Login {
      * @return {@link Challenge} instance
      */
     public Challenge createChallenge(JSON data) {
-        var challenge = session.provider().createChallenge(this, data);
+        var challenge = ISession.provider().createChallenge(this, data);
         if (challenge == null) {
             throw new AcmeProtocolException("Could not create challenge for: " + data);
         }

--- a/acme4j-client/src/main/java/org/shredzone/acme4j/Session.java
+++ b/acme4j-client/src/main/java/org/shredzone/acme4j/Session.java
@@ -48,7 +48,7 @@ import org.shredzone.acme4j.toolbox.JSON.Value;
  * or {@code https} protocol), or a special URI (via {@code acme} protocol). See the
  * documentation about valid URIs.
  */
-public class Session {
+public class Session implements ISession {
 
     private static final GenericAcmeProvider GENERIC_PROVIDER = new GenericAcmeProvider();
 
@@ -137,6 +137,7 @@ public class Session {
      *            Account {@link KeyPair}
      * @return {@link Login} to this account
      */
+    @Override
     public Login login(URL accountLocation, KeyPair accountKeyPair) {
         return new Login(accountLocation, accountKeyPair, this);
     }
@@ -144,6 +145,7 @@ public class Session {
     /**
      * Gets the ACME server {@link URI} of this session.
      */
+    @Override
     public URI getServerUri() {
         return serverUri;
     }
@@ -153,6 +155,7 @@ public class Session {
      * method is mainly for internal use.
      */
     @Nullable
+    @Override
     public String getNonce() {
         return nonce;
     }
@@ -161,6 +164,7 @@ public class Session {
      * Sets the base64 encoded nonce received by the server. This method is mainly for
      * internal use.
      */
+    @Override
     public void setNonce(@Nullable String nonce) {
         this.nonce = nonce;
     }
@@ -170,6 +174,7 @@ public class Session {
      * selected.
      */
     @Nullable
+    @Override
     public Locale getLocale() {
         return locale;
     }
@@ -180,6 +185,7 @@ public class Session {
      * The default is the system's language. If set to {@code null}, any language will be
      * accepted.
      */
+    @Override
     public void setLocale(@Nullable Locale locale) {
         this.locale = locale;
         this.languageHeader = AcmeUtils.localeToLanguageHeader(locale);
@@ -191,6 +197,7 @@ public class Session {
      *
      * @since 3.0.0
      */
+    @Override
     public String getLanguageHeader() {
         return languageHeader;
     }
@@ -201,7 +208,8 @@ public class Session {
      * @return {@link NetworkSettings}
      * @since 2.8
      */
-    @SuppressFBWarnings("EI_EXPOSE_REP")    // behavior is intended
+    @SuppressFBWarnings("EI_EXPOSE_REP")
+    @Override
     public NetworkSettings networkSettings() {
         return networkSettings;
     }
@@ -211,6 +219,7 @@ public class Session {
      *
      * @return {@link AcmeProvider}
      */
+    @Override
     public AcmeProvider provider() {
         return provider;
     }
@@ -220,6 +229,7 @@ public class Session {
      *
      * @return {@link Connection}
      */
+    @Override
     public Connection connect() {
         return provider.connect(getServerUri(), networkSettings);
     }
@@ -234,6 +244,7 @@ public class Session {
      * @throws AcmeException
      *             if the server does not offer the {@link Resource}
      */
+    @Override
     public URL resourceUrl(Resource resource) throws AcmeException {
         return resourceUrlOptional(resource)
                 .orElseThrow(() -> new AcmeNotSupportedException(resource.path()));
@@ -248,6 +259,7 @@ public class Session {
      * @return {@link URL} of the resource, or empty if the resource is not available.
      * @since 3.0.0
      */
+    @Override
     public Optional<URL> resourceUrlOptional(Resource resource) throws AcmeException {
         readDirectory();
         return Optional.ofNullable(resourceMap.get()
@@ -260,6 +272,7 @@ public class Session {
      *
      * @return {@link Metadata}. May contain no data, but is never {@code null}.
      */
+    @Override
     public Metadata getMetadata() throws AcmeException {
         readDirectory();
         return metadata.get();
@@ -273,6 +286,7 @@ public class Session {
      * @since 2.10
      */
     @Nullable
+    @Override
     public ZonedDateTime getDirectoryLastModified() {
         return directoryLastModified;
     }
@@ -286,6 +300,7 @@ public class Session {
      *         (directory has not been read yet or did not provide this information).
      * @since 2.10
      */
+    @Override
     public void setDirectoryLastModified(@Nullable ZonedDateTime directoryLastModified) {
         this.directoryLastModified = directoryLastModified;
     }
@@ -299,6 +314,7 @@ public class Session {
      * @since 2.10
      */
     @Nullable
+    @Override
     public ZonedDateTime getDirectoryExpires() {
         return directoryExpires;
     }
@@ -312,6 +328,7 @@ public class Session {
      *         information.
      * @since 2.10
      */
+    @Override
     public void setDirectoryExpires(@Nullable ZonedDateTime directoryExpires) {
         this.directoryExpires = directoryExpires;
     }
@@ -323,6 +340,7 @@ public class Session {
      * @return {@code true} if a directory is available.
      * @since 2.10
      */
+    @Override
     public boolean hasDirectory() {
         return resourceMap.get() != null;
     }
@@ -333,6 +351,7 @@ public class Session {
      *
      * @since 3.0.0
      */
+    @Override
     public void purgeDirectoryCache() {
         setDirectoryLastModified(null);
         setDirectoryExpires(null);

--- a/acme4j-client/src/main/java/org/shredzone/acme4j/connector/Connection.java
+++ b/acme4j-client/src/main/java/org/shredzone/acme4j/connector/Connection.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Optional;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
+import org.shredzone.acme4j.ISession;
 import org.shredzone.acme4j.Login;
 import org.shredzone.acme4j.Session;
 import org.shredzone.acme4j.exception.AcmeException;
@@ -41,10 +42,10 @@ public interface Connection extends AutoCloseable {
     /**
      * Resets the session nonce, by fetching a new one.
      *
-     * @param session
+     * @param ISession
      *            {@link Session} instance to fetch a nonce for
      */
-    void resetNonce(Session session) throws AcmeException;
+    void resetNonce(ISession ISession) throws AcmeException;
 
     /**
      * Sends a simple GET request.
@@ -54,14 +55,14 @@ public interface Connection extends AutoCloseable {
      *
      * @param url
      *            {@link URL} to send the request to.
-     * @param session
+     * @param ISession
      *            {@link Session} instance to be used for tracking
      * @param ifModifiedSince
      *            {@link ZonedDateTime} to be sent as "If-Modified-Since" header, or
      *            {@code null} if this header is not to be used
      * @return HTTP status that was returned
      */
-    int sendRequest(URL url, Session session, @Nullable ZonedDateTime ifModifiedSince)
+    int sendRequest(URL url, ISession ISession, @Nullable ZonedDateTime ifModifiedSince)
             throws AcmeException;
 
     /**
@@ -125,13 +126,13 @@ public interface Connection extends AutoCloseable {
      *            {@link URL} to send the request to.
      * @param claims
      *            {@link JSONBuilder} containing claims.
-     * @param session
+     * @param ISession
      *            {@link Session} instance to be used for tracking.
      * @param keypair
      *            {@link KeyPair} to be used for signing.
      * @return HTTP 200 class status that was returned
      */
-    int sendSignedRequest(URL url, JSONBuilder claims, Session session, KeyPair keypair)
+    int sendSignedRequest(URL url, JSONBuilder claims, ISession ISession, KeyPair keypair)
                 throws AcmeException;
 
     /**

--- a/acme4j-client/src/main/java/org/shredzone/acme4j/provider/AbstractAcmeProvider.java
+++ b/acme4j-client/src/main/java/org/shredzone/acme4j/provider/AbstractAcmeProvider.java
@@ -21,8 +21,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.ServiceLoader;
 
+import org.shredzone.acme4j.ISession;
 import org.shredzone.acme4j.Login;
-import org.shredzone.acme4j.Session;
 import org.shredzone.acme4j.challenge.Challenge;
 import org.shredzone.acme4j.challenge.Dns01Challenge;
 import org.shredzone.acme4j.challenge.DnsAccount01Challenge;
@@ -54,27 +54,27 @@ public abstract class AbstractAcmeProvider implements AcmeProvider {
     }
 
     @Override
-    public JSON directory(Session session, URI serverUri) throws AcmeException {
-        var expires = session.getDirectoryExpires();
+    public JSON directory(ISession ISession, URI serverUri) throws AcmeException {
+        var expires = ISession.getDirectoryExpires();
         if (expires != null && expires.isAfter(ZonedDateTime.now())) {
             // The cached directory is still valid
             return null;
         }
 
-        try (var conn = connect(serverUri, session.networkSettings())) {
-            var lastModified = session.getDirectoryLastModified();
-            var rc = conn.sendRequest(resolve(serverUri), session, lastModified);
+        try (var conn = connect(serverUri, ISession.networkSettings())) {
+            var lastModified = ISession.getDirectoryLastModified();
+            var rc = conn.sendRequest(resolve(serverUri), ISession, lastModified);
             if (lastModified != null && rc == HTTP_NOT_MODIFIED) {
                 // The server has not been modified since
                 return null;
             }
 
             // evaluate caching headers
-            session.setDirectoryLastModified(conn.getLastModified().orElse(null));
-            session.setDirectoryExpires(conn.getExpiration().orElse(null));
+            ISession.setDirectoryLastModified(conn.getLastModified().orElse(null));
+            ISession.setDirectoryExpires(conn.getExpiration().orElse(null));
 
             // use nonce header if there is one, saves a HEAD request...
-            conn.getNonce().ifPresent(session::setNonce);
+            conn.getNonce().ifPresent(ISession::setNonce);
 
             return conn.readJsonResponse();
         }

--- a/acme4j-client/src/main/java/org/shredzone/acme4j/provider/AcmeProvider.java
+++ b/acme4j-client/src/main/java/org/shredzone/acme4j/provider/AcmeProvider.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.ServiceLoader;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
+import org.shredzone.acme4j.ISession;
 import org.shredzone.acme4j.Login;
 import org.shredzone.acme4j.Session;
 import org.shredzone.acme4j.challenge.Challenge;
@@ -74,7 +75,7 @@ public interface AcmeProvider {
      * The default implementation resolves the server URI and fetches the directory via
      * HTTP request. Subclasses may override this method, e.g. if the directory is static.
      *
-     * @param session
+     * @param ISession
      *            {@link Session} to be used
      * @param serverUri
      *            Server {@link URI}
@@ -82,7 +83,7 @@ public interface AcmeProvider {
      * been changed since the last request.
      */
     @Nullable
-    JSON directory(Session session, URI serverUri) throws AcmeException;
+    JSON directory(ISession ISession, URI serverUri) throws AcmeException;
 
     /**
      * Creates a {@link Challenge} instance for the given challenge data.

--- a/acme4j-client/src/main/java/org/shredzone/acme4j/provider/sslcom/SslComAcmeProvider.java
+++ b/acme4j-client/src/main/java/org/shredzone/acme4j/provider/sslcom/SslComAcmeProvider.java
@@ -18,7 +18,7 @@ import java.net.URI;
 import java.net.URL;
 import java.util.Map;
 
-import org.shredzone.acme4j.Session;
+import org.shredzone.acme4j.ISession;
 import org.shredzone.acme4j.exception.AcmeException;
 import org.shredzone.acme4j.exception.AcmeProtocolException;
 import org.shredzone.acme4j.provider.AbstractAcmeProvider;
@@ -74,12 +74,12 @@ public class SslComAcmeProvider extends AbstractAcmeProvider {
 
     @Override
     @SuppressWarnings("unchecked")
-    public JSON directory(Session session, URI serverUri) throws AcmeException {
+    public JSON directory(ISession ISession, URI serverUri) throws AcmeException {
         // This is a workaround for a bug at SSL.com. It requires account registration
         // by EAB, but the "externalAccountRequired" flag in the directory is set to
         // false. This patch reads the directory and forcefully sets the flag to true.
         // The entire method can be removed once it is fixed on SSL.com side.
-        var superdirectory = super.directory(session, serverUri);
+        var superdirectory = super.directory(ISession, serverUri);
         if (superdirectory == null) {
             return null;
         }

--- a/acme4j-client/src/test/java/org/shredzone/acme4j/AccountBuilderTest.java
+++ b/acme4j-client/src/test/java/org/shredzone/acme4j/AccountBuilderTest.java
@@ -68,7 +68,7 @@ public class AccountBuilderTest {
             }
 
             @Override
-            public int sendSignedRequest(URL url, JSONBuilder claims, Session session, KeyPair keypair) {
+            public int sendSignedRequest(URL url, JSONBuilder claims, ISession session, KeyPair keypair) {
                 assertThat(session).isNotNull();
                 assertThat(url).isEqualTo(resourceUrl);
                 assertThatJson(claims.toString()).isEqualTo(getJSON("newAccount").toString());
@@ -143,7 +143,7 @@ public class AccountBuilderTest {
 
         var provider = new TestableConnectionProvider() {
             @Override
-            public int sendSignedRequest(URL url, JSONBuilder claims, Session session, KeyPair keypair) {
+            public int sendSignedRequest(URL url, JSONBuilder claims, ISession session, KeyPair keypair) {
                 assertThat(session).isNotNull();
                 assertThat(url).isEqualTo(resourceUrl);
                 assertThat(keypair).isEqualTo(accountKey);
@@ -217,7 +217,7 @@ public class AccountBuilderTest {
 
         var provider = new TestableConnectionProvider() {
             @Override
-            public int sendSignedRequest(URL url, JSONBuilder claims, Session session, KeyPair keypair) {
+            public int sendSignedRequest(URL url, JSONBuilder claims, ISession session, KeyPair keypair) {
                 assertThat(session).isNotNull();
                 assertThat(url).isEqualTo(resourceUrl);
                 assertThatJson(claims.toString()).isEqualTo(getJSON("newAccountOnlyExisting").toString());

--- a/acme4j-client/src/test/java/org/shredzone/acme4j/CertificateTest.java
+++ b/acme4j-client/src/test/java/org/shredzone/acme4j/CertificateTest.java
@@ -262,7 +262,7 @@ public class CertificateTest {
 
         var provider = new TestableConnectionProvider() {
             @Override
-            public int sendSignedRequest(URL url, JSONBuilder claims, Session session, KeyPair keypair) {
+            public int sendSignedRequest(URL url, JSONBuilder claims, ISession session, KeyPair keypair) {
                 assertThat(url).isEqualTo(resourceUrl);
                 assertThatJson(claims.toString()).isEqualTo(getJSON("revokeCertificateWithReasonRequest").toString());
                 assertThat(session).isNotNull();
@@ -304,7 +304,7 @@ public class CertificateTest {
             }
 
             @Override
-            public int sendRequest(URL url, Session session, ZonedDateTime ifModifiedSince) {
+            public int sendRequest(URL url, ISession session, ZonedDateTime ifModifiedSince) {
                 assertThat(url).isEqualTo(certResourceUrl);
                 assertThat(session).isNotNull();
                 assertThat(ifModifiedSince).isNull();

--- a/acme4j-client/src/test/java/org/shredzone/acme4j/RenewalInfoTest.java
+++ b/acme4j-client/src/test/java/org/shredzone/acme4j/RenewalInfoTest.java
@@ -47,7 +47,7 @@ public class RenewalInfoTest {
     public void testGetters() throws Exception {
         var provider = new TestableConnectionProvider() {
             @Override
-            public int sendRequest(URL url, Session session, ZonedDateTime ifModifiedSince) {
+            public int sendRequest(URL url, ISession session, ZonedDateTime ifModifiedSince) {
                 assertThat(url).isEqualTo(locationUrl);
                 assertThat(session).isNotNull();
                 assertThat(ifModifiedSince).isNull();

--- a/acme4j-client/src/test/java/org/shredzone/acme4j/connector/DummyConnection.java
+++ b/acme4j-client/src/test/java/org/shredzone/acme4j/connector/DummyConnection.java
@@ -22,8 +22,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
+import org.shredzone.acme4j.ISession;
 import org.shredzone.acme4j.Login;
-import org.shredzone.acme4j.Session;
 import org.shredzone.acme4j.exception.AcmeException;
 import org.shredzone.acme4j.toolbox.JSON;
 import org.shredzone.acme4j.toolbox.JSONBuilder;
@@ -35,12 +35,12 @@ import org.shredzone.acme4j.toolbox.JSONBuilder;
 public class DummyConnection implements Connection {
 
     @Override
-    public void resetNonce(Session session) {
+    public void resetNonce(ISession ISession) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public int sendRequest(URL url, Session session, ZonedDateTime ifModifiedSince) {
+    public int sendRequest(URL url, ISession ISession, ZonedDateTime ifModifiedSince) {
         throw new UnsupportedOperationException();
     }
 
@@ -61,7 +61,7 @@ public class DummyConnection implements Connection {
     }
 
     @Override
-    public int sendSignedRequest(URL url, JSONBuilder claims, Session session, KeyPair keypair) {
+    public int sendSignedRequest(URL url, JSONBuilder claims, ISession ISession, KeyPair keypair) {
         throw new UnsupportedOperationException();
     }
 

--- a/acme4j-client/src/test/java/org/shredzone/acme4j/connector/SessionProviderTest.java
+++ b/acme4j-client/src/test/java/org/shredzone/acme4j/connector/SessionProviderTest.java
@@ -21,6 +21,7 @@ import java.net.URL;
 import java.util.ServiceLoader;
 
 import org.junit.jupiter.api.Test;
+import org.shredzone.acme4j.ISession;
 import org.shredzone.acme4j.Login;
 import org.shredzone.acme4j.Session;
 import org.shredzone.acme4j.challenge.Challenge;
@@ -92,7 +93,7 @@ public class SessionProviderTest {
         }
 
         @Override
-        public JSON directory(Session session, URI serverUri) {
+        public JSON directory(ISession ISession, URI serverUri) {
             throw new UnsupportedOperationException();
         }
 
@@ -120,7 +121,7 @@ public class SessionProviderTest {
         }
 
         @Override
-        public JSON directory(Session session, URI serverUri) {
+        public JSON directory(ISession ISession, URI serverUri) {
             throw new UnsupportedOperationException();
         }
 

--- a/acme4j-client/src/test/java/org/shredzone/acme4j/provider/TestableConnectionProvider.java
+++ b/acme4j-client/src/test/java/org/shredzone/acme4j/provider/TestableConnectionProvider.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
 
+import org.shredzone.acme4j.ISession;
 import org.shredzone.acme4j.Login;
 import org.shredzone.acme4j.Session;
 import org.shredzone.acme4j.challenge.Challenge;
@@ -99,7 +100,7 @@ public class TestableConnectionProvider extends DummyConnection implements AcmeP
     /**
      * Creates a {@link Session} that uses this {@link AcmeProvider}.
      */
-    public Session createSession() {
+    public ISession createSession() {
         return TestUtils.session(this);
     }
 
@@ -132,7 +133,7 @@ public class TestableConnectionProvider extends DummyConnection implements AcmeP
     }
 
     @Override
-    public JSON directory(Session session, URI serverUri) {
+    public JSON directory(ISession ISession, URI serverUri) {
         if (directory.toMap().isEmpty()) {
             throw new UnsupportedOperationException();
         }

--- a/acme4j-client/src/test/java/org/shredzone/acme4j/toolbox/TestUtils.java
+++ b/acme4j-client/src/test/java/org/shredzone/acme4j/toolbox/TestUtils.java
@@ -48,6 +48,7 @@ import org.jose4j.json.JsonUtil;
 import org.jose4j.jwk.JsonWebKey;
 import org.jose4j.jwk.JsonWebKey.OutputControlLevel;
 import org.jose4j.keys.HmacKey;
+import org.shredzone.acme4j.ISession;
 import org.shredzone.acme4j.Login;
 import org.shredzone.acme4j.Problem;
 import org.shredzone.acme4j.Session;
@@ -119,7 +120,7 @@ public final class TestUtils {
     /**
      * Creates a {@link Session} instance. It uses {@link #ACME_SERVER_URI} as server URI.
      */
-    public static Session session() {
+    public static ISession session() {
         return new Session(URI.create(ACME_SERVER_URI));
     }
 
@@ -157,7 +158,7 @@ public final class TestUtils {
      * @param provider
      *            {@link AcmeProvider} to be used in this session
      */
-    public static Session session(final AcmeProvider provider) {
+    public static ISession session(final AcmeProvider provider) {
         return new Session(URI.create(ACME_SERVER_URI)) {
             @Override
             public AcmeProvider provider() {

--- a/acme4j-example/src/main/java/org/shredzone/acme4j/example/ClientTest.java
+++ b/acme4j-example/src/main/java/org/shredzone/acme4j/example/ClientTest.java
@@ -30,14 +30,7 @@ import java.util.function.Supplier;
 import javax.swing.JOptionPane;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.shredzone.acme4j.Account;
-import org.shredzone.acme4j.AccountBuilder;
-import org.shredzone.acme4j.Authorization;
-import org.shredzone.acme4j.Certificate;
-import org.shredzone.acme4j.Order;
-import org.shredzone.acme4j.Problem;
-import org.shredzone.acme4j.Session;
-import org.shredzone.acme4j.Status;
+import org.shredzone.acme4j.*;
 import org.shredzone.acme4j.challenge.Challenge;
 import org.shredzone.acme4j.challenge.Dns01Challenge;
 import org.shredzone.acme4j.challenge.Http01Challenge;
@@ -117,11 +110,11 @@ public class ClientTest {
         KeyPair userKeyPair = loadOrCreateUserKeyPair();
 
         // Create a session.
-        Session session = new Session(CA_URI);
+        ISession ISession = new Session(CA_URI);
 
         // Get the Account.
         // If there is no account yet, create a new one.
-        Account acct = findOrRegisterAccount(session, userKeyPair);
+        Account acct = findOrRegisterAccount(ISession, userKeyPair);
 
         // Load or create a key pair for the domains. This should not be the userKeyPair!
         KeyPair domainKeyPair = loadOrCreateDomainKeyPair();
@@ -220,13 +213,13 @@ public class ClientTest {
      * If you need to get access to your account later, reconnect to it via {@link
      * Session#login(URL, KeyPair)} by using the stored location.
      *
-     * @param session
+     * @param ISession
      *         {@link Session} to bind with
      * @return {@link Account}
      */
-    private Account findOrRegisterAccount(Session session, KeyPair accountKey) throws AcmeException {
+    private Account findOrRegisterAccount(ISession ISession, KeyPair accountKey) throws AcmeException {
         // Ask the user to accept the TOS, if server provides us with a link.
-        Optional<URI> tos = session.getMetadata().getTermsOfService();
+        Optional<URI> tos = ISession.getMetadata().getTermsOfService();
         if (tos.isPresent()) {
             acceptAgreement(tos.get());
         }
@@ -245,7 +238,7 @@ public class ClientTest {
             accountBuilder.withKeyIdentifier(EAB_KID, EAB_HMAC);
         }
 
-        Account account = accountBuilder.create(session);
+        Account account = accountBuilder.create(ISession);
         LOG.info("Registered a new user, URL: {}", account.getLocation());
 
         return account;

--- a/acme4j-it/src/test/java/org/shredzone/acme4j/it/pebble/AccountIT.java
+++ b/acme4j-it/src/test/java/org/shredzone/acme4j/it/pebble/AccountIT.java
@@ -20,11 +20,7 @@ import java.net.URI;
 import java.security.KeyPair;
 
 import org.junit.jupiter.api.Test;
-import org.shredzone.acme4j.Account;
-import org.shredzone.acme4j.AccountBuilder;
-import org.shredzone.acme4j.Login;
-import org.shredzone.acme4j.Session;
-import org.shredzone.acme4j.Status;
+import org.shredzone.acme4j.*;
 import org.shredzone.acme4j.exception.AcmeException;
 import org.shredzone.acme4j.exception.AcmeServerException;
 import org.shredzone.acme4j.exception.AcmeUnauthorizedException;
@@ -136,8 +132,8 @@ public class AccountIT extends PebbleITBase {
     public void testNotExisting() {
         var ex = assertThrows(AcmeServerException.class, () -> {
             KeyPair keyPair = createKeyPair();
-            Session session = new Session(pebbleURI());
-            new AccountBuilder().onlyExisting().useKeyPair(keyPair).create(session);
+            ISession ISession = new Session(pebbleURI());
+            new AccountBuilder().onlyExisting().useKeyPair(keyPair).create(ISession);
         });
         assertThat(ex.getType()).isEqualTo(URI.create("urn:ietf:params:acme:error:accountDoesNotExist"));
     }
@@ -189,8 +185,8 @@ public class AccountIT extends PebbleITBase {
         acct.changeKey(newKeyPair);
 
         assertThrows(AcmeServerException.class, () -> {
-            Session sessionOldKey = new Session(pebbleURI());
-            Account oldAccount = sessionOldKey.login(location, keyPair).getAccount();
+            ISession ISessionOldKey = new Session(pebbleURI());
+            Account oldAccount = ISessionOldKey.login(location, keyPair).getAccount();
             oldAccount.fetch();
         }, "Old account key is still accessible");
 
@@ -221,8 +217,8 @@ public class AccountIT extends PebbleITBase {
         // Make sure account cannot be accessed any more...
         var ex = assertThrows(AcmeUnauthorizedException.class,
                 () -> {
-            Session session2 = new Session(pebbleURI());
-            Account acct2 = session2.login(location, keyPair).getAccount();
+            ISession ISession2 = new Session(pebbleURI());
+            Account acct2 = ISession2.login(location, keyPair).getAccount();
             acct2.fetch();
         }, "Account can still be accessed");
         assertThat(ex.getMessage()).isEqualTo("Account has been deactivated");

--- a/acme4j-it/src/test/java/org/shredzone/acme4j/it/pebble/OrderIT.java
+++ b/acme4j-it/src/test/java/org/shredzone/acme4j/it/pebble/OrderIT.java
@@ -26,12 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.shredzone.acme4j.AccountBuilder;
-import org.shredzone.acme4j.Authorization;
-import org.shredzone.acme4j.Certificate;
-import org.shredzone.acme4j.RevocationReason;
-import org.shredzone.acme4j.Session;
-import org.shredzone.acme4j.Status;
+import org.shredzone.acme4j.*;
 import org.shredzone.acme4j.challenge.Challenge;
 import org.shredzone.acme4j.challenge.Dns01Challenge;
 import org.shredzone.acme4j.challenge.DnsAccount01Challenge;
@@ -252,19 +247,19 @@ public class OrderIT extends PebbleITBase {
      * Revokes a certificate by calling {@link Certificate#revoke(RevocationReason)}.
      * This is the standard way to revoke a certificate.
      */
-    private static void standardRevoker(Session session, Certificate certificate,
-            KeyPair keyPair, KeyPair domainKeyPair) throws Exception {
+    private static void standardRevoker(ISession ISession, Certificate certificate,
+                                        KeyPair keyPair, KeyPair domainKeyPair) throws Exception {
         certificate.revoke(RevocationReason.KEY_COMPROMISE);
     }
 
     /**
      * Revokes a certificate by calling
-     * {@link Certificate#revoke(Session, KeyPair, X509Certificate, RevocationReason)}.
+     * {@link Certificate#revoke(ISession, KeyPair, X509Certificate, RevocationReason)}.
      * This way can be used when the account key was lost.
      */
-    private static void domainKeyRevoker(Session session, Certificate certificate,
-            KeyPair keyPair, KeyPair domainKeyPair) throws Exception {
-        Certificate.revoke(session, domainKeyPair, certificate.getCertificate(),
+    private static void domainKeyRevoker(ISession ISession, Certificate certificate,
+                                         KeyPair keyPair, KeyPair domainKeyPair) throws Exception {
+        Certificate.revoke(ISession, domainKeyPair, certificate.getCertificate(),
                 RevocationReason.KEY_COMPROMISE);
     }
 
@@ -275,8 +270,8 @@ public class OrderIT extends PebbleITBase {
 
     @FunctionalInterface
     private interface Revoker {
-        void revoke(Session session, Certificate certificate, KeyPair keyPair,
-            KeyPair domainKeyPair) throws Exception;
+        void revoke(ISession ISession, Certificate certificate, KeyPair keyPair,
+                    KeyPair domainKeyPair) throws Exception;
     }
 
 }


### PR DESCRIPTION
We want to use this lib in an environement where Java 11 is not available. By introducing an interface for the Session class and using the interface Connection we were able to port this lib to our environment. 

As we don't want to introduce a renamed of the Session object we named the interface `ISession` so that no implementations are broken. 

We hope that this little changement can help people adopt ACME4J lib in many projects. 