### PR TITLE
Refine regex pattern for link collection

### DIFF
--- a/acme4j-client/src/main/java/org/shredzone/acme4j/connector/DefaultConnection.java
+++ b/acme4j-client/src/main/java/org/shredzone/acme4j/connector/DefaultConnection.java
@@ -582,12 +582,12 @@ public class DefaultConnection implements Connection {
      * @return Collection of links, unconverted
      */
     private Collection<String> collectLinks(String relation) {
-        var p = Pattern.compile("<(.*?)>\\s*;\\s*rel=\"?" + Pattern.quote(relation) + "\"?");
-
+        var p = Pattern.compile("<([^>]+)>\\s*;[^<]*?\\brel=\"?" + Pattern.quote(relation) + "\"?(?:[\\s,;]|$)");
+        
         return getResponse().headers().allValues(LINK_HEADER)
                 .stream()
                 .map(p::matcher)
-                .filter(Matcher::matches)
+                .flatMap(Matcher::results)
                 .map(m -> m.group(1))
                 .peek(location -> LOG.debug("Link: {} -> {}", relation, location))
                 .toList();


### PR DESCRIPTION
We're seeing acme4j clients having a hard time connecting to Google Trust Services due to this header check. This regex should be less prone to erroneous breakage.